### PR TITLE
Changed to only add '.dat' to file path if filepath has no extension already

### DIFF
--- a/twixtools/twixtools.py
+++ b/twixtools/twixtools.py
@@ -8,6 +8,7 @@ twixtools: provides reading and limited writing capability of Siemens MRI raw
 import os
 import re
 import numpy as np
+from pathlib import Path
 from tqdm import tqdm
 
 import twixtools.twixprot as twixprot
@@ -53,7 +54,8 @@ def read_twix(infile, include_scans=None, parse_prot=True, parse_data=True,
     """
     if isinstance(infile, str):
         # assume that complete path is given
-        if infile[-4:].lower() != '.dat':
+        # check if filepath contains an extension
+        if len(Path(infile).suffix) == 0:
             infile += '.dat'   # adds filetype ending to file
     else:
         # filename not a string, so assume that it is the MeasID

--- a/twixtools/twixtools.py
+++ b/twixtools/twixtools.py
@@ -8,7 +8,6 @@ twixtools: provides reading and limited writing capability of Siemens MRI raw
 import os
 import re
 import numpy as np
-from pathlib import Path
 from tqdm import tqdm
 
 import twixtools.twixprot as twixprot
@@ -55,7 +54,7 @@ def read_twix(infile, include_scans=None, parse_prot=True, parse_data=True,
     if isinstance(infile, str):
         # assume that complete path is given
         # check if filepath contains an extension
-        if len(Path(infile).suffix) == 0:
+        if len(os.path.splitext(infile)[1]) == 0:
             infile += '.dat'   # adds filetype ending to file
     else:
         # filename not a string, so assume that it is the MeasID


### PR DESCRIPTION
The proposed change slightly changes the loader so that the ".dat" extension is only added if the given input file contains no extension already. Without this change all input files must have the ".dat" extension and the loader fails to load any files with a different file extensions. 

For example, when trying to load the file ```data.twix``` with
```python
import twixtools
data = twixtools.read_twix('data.twix')
```
the loader would fail previously