### PR TITLE
Addressing Hexadecimal Value Handling for Newer Baselines

### DIFF
--- a/twixtools/map_twix.py
+++ b/twixtools/map_twix.py
@@ -278,7 +278,7 @@ class twix_array():
                        'user_func': list()}
 
         # 'Ave' should be averaged by default, Idx indices should be ignored:
-        for dim in ['Ide', 'Idd', 'Idc', 'Idb', 'Ida', 'Seg', 'Ave']:
+        for dim in ['Seg', 'Ave']:
             self._flags['average'][dim] = True
 
         # set flags that were passed in constructor call

--- a/twixtools/twixprot.py
+++ b/twixtools/twixprot.py
@@ -52,7 +52,10 @@ def try_cast(value, key):
             pass
     elif key.startswith('uc'):
         try:
-            value = int(value, 16)
+            if value.startswith('0x'):
+                value = int(value, 16)
+            else:
+                value = int(value)
         except ValueError:
             pass
     else:  # try to convert everything else to float


### PR DESCRIPTION
The previous baseline versions stored values in hexadecimal format (e.g., VB). In contrast, the newer baselines (I verified with VE) store values in decimal format within the header, eliminating the need for conversion. The twixtool assumes that parameters with names starting with 'uc' were in hexadecimal format and performed unnecessary conversions, resulting in incorrect values. To address this issue, I introduced a condition that explicitly checks whether the value is in hexadecimal format or not.
This needs to be verified with NX as well. 