### PR TITLE
correcting index of partition dim.

### DIFF
--- a/twixtools/map_twix.py
+++ b/twixtools/map_twix.py
@@ -569,7 +569,7 @@ class twix_array():
 
             # When the Line Counter (Counter.Lin) is not smaller than its shape,
             # the data will be stored in the front, and may cause problems.
-            if Counter.Lin >= self_shape[-3] or Counter.Par >= self_shape[-5]:
+            if Counter.Lin >= self_shape[-3] or Counter.Par >= self_shape[-6]:
                 continue
 
             counters = [getattr(Counter, key) for key in Counter_sel]


### PR DESCRIPTION
Typo in index for partition. 
While 2D data encounters no issues, proper mapping is hindered when handling 3D data.