### PR TITLE
Fixed PMU loading crashing twix parsing for weird sequence

### DIFF
--- a/twixtools/pmu.py
+++ b/twixtools/pmu.py
@@ -42,7 +42,10 @@ class PMUblock():
         self.trigger = dict()
         while i < len(data):
             magic, = struct.unpack('I', data[i:i+4])
-            key = magic_pmu[magic]
+            if magic in magic_pmu:
+                key = magic_pmu[magic]
+            else:
+                key = "UNKNOWN"
             i += 4
             if key == 'END':
                 break


### PR DESCRIPTION
The pull request adds an additional check to the PMU loading to allow the code to not crash sequences that contain no or weird PMU data. The additional check checks if the magic number is in the magic_pmu dictionary before trying to access it. If not the key type is set to "UNKNOWN" to make the rest of the code still work and continue. 