### PR TITLE
Excluded PatientID from conversion to float

### DIFF
--- a/twixtools/twixprot.py
+++ b/twixtools/twixprot.py
@@ -61,7 +61,7 @@ def try_cast(value, key):
                 value = int(value)
         except ValueError:
             pass
-    else:  # try to convert everything else to float
+    elif key != "PatientID":  # try to convert everything else except PatientID tags to float
         # obsolete: elif key.startswith('d') or key.startswith('fl'):
         try:
             value = float(value)


### PR DESCRIPTION
This small change excludes the PatientID from the conversion to float, which can be a problem for sites where the PatientID consists only of numbers, but for example contains leading zeros, e.g. 0014629281 - which should be retained when loading the parameter. As PatientID by DICOM is also a string it should also be treated as a string when loading it from the raw data. 