### PR TITLE
Make compatible with scipy => 1.14

### DIFF
--- a/twixtools/recon_helpers.py
+++ b/twixtools/recon_helpers.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
 
 def to_freqdomain(data, x_in_timedomain=True, axis=-1):
@@ -65,7 +65,7 @@ def calc_regrid_traj(prot, ncol=None):
     # make sure that gr_adc is always positive
     # (rs_traj needs to be strictly monotonic)
     gr_adc = np.maximum(gr_adc, 1e-4)
-    rs_traj = (np.append(0, cumtrapz(gr_adc)) - ncol // 2) / np.sum(gr_adc)
+    rs_traj = (np.append(0, cumulative_trapezoid(gr_adc)) - ncol // 2) / np.sum(gr_adc)
     rs_traj -= np.mean(rs_traj[ncol//2-1:ncol//2+1])
 
     # scale rs_traj by kmax (only works if all slices have same FoV!!!)


### PR DESCRIPTION
Scipy deprecated the cumtrapz function. Twixtools no longer work with scipy 1.14 without this patch.

Source:
https://docs.scipy.org/doc/scipy/release/1.12.0-notes.html

> scipy.integrate.trapz, scipy.integrate.cumtrapz, and scipy.integrate.simps have been deprecated in favour of [scipy.integrate.trapezoid](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.trapezoid.html#scipy.integrate.trapezoid), [scipy.integrate.cumulative_trapezoid](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.cumulative_trapezoid.html#scipy.integrate.cumulative_trapezoid), and [scipy.integrate.simpson](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.simpson.html#scipy.integrate.simpson) respectively and will be removed in SciPy 1.14.