### PR TITLE
make recon_helpers.py work for scipy versions >= 1.14.0

### DIFF
--- a/twixtools/recon_helpers.py
+++ b/twixtools/recon_helpers.py
@@ -1,6 +1,10 @@
 import numpy as np
-from scipy.integrate import cumtrapz
-
+import pkg_resources
+scipy_version = pkg_resources.get_distribution("scipy").version
+if scipy_version >= '1.14.0':
+    from scipy.integrate import cumulative_trapezoid as cumtrapz
+else:
+    from scipy.integrate import cumtrapz
 
 def to_freqdomain(data, x_in_timedomain=True, axis=-1):
     if not x_in_timedomain:


### PR DESCRIPTION
In scipy version 1.14.0 the function `cumtrapz()` does not exist anymore and is replaced by `cumulative_trapezoid()`. The changes of this PR make sure the correct function name is imported.