### PR TITLE
RuntimeWarning: overflow encountered in scalar subtract

### DIFF
--- a/twixtools/map_twix.py
+++ b/twixtools/map_twix.py
@@ -242,7 +242,7 @@ class twix_array():
         )
 
         # dtype that includes all dims:
-        self.dt_dims = np.dtype([(name, "<u2") for name in self.dim_order])
+        self.dt_dims = np.dtype([(name, "<i2") for name in self.dim_order])
 
         # dtype that only includes counters (no cha & col)
         self.dt_counters = np.dtype([(n, "<u2") for n in self.dim_order[:-2]])

--- a/twixtools/map_twix.py
+++ b/twixtools/map_twix.py
@@ -242,7 +242,7 @@ class twix_array():
         )
 
         # dtype that includes all dims:
-        self.dt_dims = np.dtype([(name, "<i2") for name in self.dim_order])
+        self.dt_dims = np.dtype([(name, "<u2") for name in self.dim_order])
 
         # dtype that only includes counters (no cha & col)
         self.dt_counters = np.dtype([(n, "<u2") for n in self.dim_order[:-2]])
@@ -374,7 +374,7 @@ class twix_array():
     def par_offset(self):
         offset = 0
         if self.hdr is not None and self.flags['zf_missing_lines'] and self.base_size['Par']//2 > self.kspace_center_lin + 1:
-            offset = self.base_size['Par'] - 2 * self.kspace_center_par
+            offset = int(self.base_size['Par']) - 2 * self.kspace_center_par
         return offset
 
     @property


### PR DESCRIPTION
In the following method (file map_twix.py):

```python
def par_offset(self):
    offset = 0
    if self.hdr is not None and self.flags['zf_missing_lines'] and self.base_size['Par']//2 > self.kspace_center_lin + 1:
        offset = self.base_size['Par'] - 2 * self.kspace_center_par
    return offset
```

The values in the dictionary `self.base_size` are of type `uint16`. When performing operations with `int32` variables, an overflow can occur. 

For example, in the method `par_offset`, I encountered the following case when reconstructing an mprage data:
- `self.base_size['Par']` was 255.
- `self.kspace_center_par` was 128.

The subtraction result should be `-1`; however, due to `self.base_size['Par']` being `uint16`, the result is interpreted as `65535` (=`2^16 - 1`). Consequently, I observed the following runtime warning:

```
twixtools/map_twix.py:377: RuntimeWarning: overflow encountered in scalar subtract
  offset = self.base_size['Par'] - 2 * self.kspace_center_par
```

### Proposed Solution

To avoid such overflows, I suggest changing the type of `self.base_size` values from `uint16` to `int16`. This modification ensures that subtraction results are correctly interpreted as negative when applicable.

