### PR TITLE
Changed slice look-up to only use image data

### DIFF
--- a/twixtools/geometry.py
+++ b/twixtools/geometry.py
@@ -50,7 +50,7 @@ def prs2sct_mdb(twix, sliceno):
     # find first mdb which belongs to the slice:
     index = -1
     for i,m in enumerate(twix['mdb']):
-        if m.mdh.Counter.Sli == sliceno:
+        if m.mdh.Counter.Sli == sliceno and m.is_image_scan():
             index = i
             break
 


### PR DESCRIPTION
Small fix that changes the new slice loop-up in the geometry calculation to only consider image scans. Otherwise it would also pick calibration/syncdata, which sometimes don't have geometry information in the mdh, this then fails geometry calculation. 